### PR TITLE
feature/discord-oauth

### DIFF
--- a/src/config/interface.ts
+++ b/src/config/interface.ts
@@ -47,6 +47,10 @@ export interface core_profile {
   classification: string;
   past_applications?: past_entry[];
   past_events?: past_entry[];
+  discord_verified?: boolean;
+  username?: string;
+  discriminator?: string;
+  snowflake?: string;
 }
 
 export interface profile {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,6 +44,7 @@ ReactDOM.render(
       redirectUri={window.location.origin + window.location.pathname + window.location.search}
       audience={config.audience}
       scope={"read:current_user update:current_user_metadata"}
+      useRefreshTokens={true}
     >
       <Provider store={store}>
         <Sentry.ErrorBoundary fallback={<Error />}>

--- a/src/views/Profile/Discord.css
+++ b/src/views/Profile/Discord.css
@@ -1,0 +1,13 @@
+.steps-content {
+    min-height: 200px;
+    margin-top: 16px;
+    padding-top: 80px;
+    text-align: center;
+    background-color: rgb(120, 119, 119);
+    border: 1px #e9e9e9;
+    border-radius: 2px;
+  }
+  
+  .steps-action {
+    margin-top: 24px;
+  }

--- a/src/views/Profile/Discord.tsx
+++ b/src/views/Profile/Discord.tsx
@@ -1,0 +1,138 @@
+import { Steps, Button, message } from "antd";
+import React, { Fragment, useState, useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import Button2 from "../../components/OrangeButton/OrangeButton";
+import * as Sentry from "@sentry/react";
+import axios from "axios";
+import "./Discord.css";
+
+const { Step } = Steps;
+
+const DiscordPane = () => {
+  const [current, setCurrent] = useState(0);
+  const [stepComplete, setStepComplete] = useState(false);
+  const {
+    isAuthenticated,
+    isLoading,
+    getAccessTokenSilently,
+    user,
+    loginWithRedirect,
+  } = useAuth0();
+
+  const next = () => {
+    setStepComplete(false);
+    setCurrent(current + 1);
+  };
+
+  const signin = async () => {
+    const config = {
+      headers: {
+        Authorization: `Bearer ${await getAccessTokenSilently()}`,
+      },
+    };
+    const result = await axios.get(
+      (process.env.REACT_APP_CLOUD_FUNCTION_URL as string) + "/auth0/discord",
+      config
+    );
+    console.log(result);
+    if (result.data.discord_authentication) {
+      setStepComplete(true);
+    } else {
+      await loginWithRedirect({
+        appState: { targetUrl: "/profile" },
+        connection: "Discord",
+      });
+    }
+  };
+
+  const steps = [
+    {
+      title: "Authentication",
+      content: (
+        <Fragment>
+          <h3>Welcome to the discord integration utility.</h3>
+          <p>
+            Complete the following steps to link your ACM account to discord.
+          </p>
+          <p>
+            This will help you sync your event attendence and activity from
+            discord over to the portal.
+          </p>
+          {!stepComplete ? (
+            <Fragment>
+              {" "}
+              <p>Step 1: Sign in with discord</p>{" "}
+              <Button2 text="Sign in" onClick={signin} />{" "}
+            </Fragment>
+          ) : (
+            <p>Thank you, please click next.</p>
+          )}
+        </Fragment>
+      ),
+    },
+    {
+      title: "Joining",
+      content: (
+        <Fragment>
+          <h3>Joining the ACM Discord Server</h3>
+          <p>
+            Next we would like you to join the ACM Discord Server. 
+          </p>
+          <p>
+            This will help you sync your event attendence and activity from
+            discord over to the portal.
+          </p>
+          {!stepComplete ? (
+            <Fragment>
+              {" "}
+              <p>Step 1: Sign in with discord</p>{" "}
+              <Button2 text="Sign in" onClick={signin} />{" "}
+            </Fragment>
+          ) : (
+            <p>Thank you, please click next.</p>
+          )}
+        </Fragment>
+      ),
+    },
+    {
+      title: "Verification",
+      content: "Last-content",
+    },
+    {
+      title: "Confirmation",
+      content: "Last-content",
+    },
+  ];
+
+  return (
+    <Fragment>
+      <Steps current={current}>
+        {steps.map((item) => (
+          <Step key={item.title} title={item.title} />
+        ))}
+      </Steps>
+      <div className="steps-content">{steps[current].content}</div>
+      <div className="steps-action">
+        {current < steps.length - 1 && (
+          <Button
+            type="primary"
+            onClick={() => next()}
+            disabled={!stepComplete}
+          >
+            Next
+          </Button>
+        )}
+        {current === steps.length - 1 && (
+          <Button
+            type="primary"
+            onClick={() => message.success("Verification Complete")}
+          >
+            Done
+          </Button>
+        )}
+      </div>
+    </Fragment>
+  );
+};
+
+export default DiscordPane;

--- a/src/views/Profile/Profile.tsx
+++ b/src/views/Profile/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, Fragment } from "react";
 import { Tabs, Layout } from "antd";
 import Navbar from "../../components/Navbar/DarkNavbar";
 import "./Profile.css";
@@ -24,6 +24,26 @@ const Profile = () => {
       history.push("/newprofile");
     }
   }, [isLoading, isAuthenticated, user_profile, history]);
+
+  const discPane =
+    user_profile.profile?.discord_verified || false ? (
+      <Fragment>
+        <h1 style={{ color: "white", marginBottom: 20 }}>
+          Your Discord Profile:
+        </h1>
+        <p>
+          <strong>Discord ID:</strong> {user_profile.profile?.snowflake}
+        </p>
+        <p>
+          <strong>Username:</strong>{" "}
+          {user_profile.profile?.username +
+            "#" +
+            user_profile.profile?.discriminator}
+        </p>
+      </Fragment>
+    ) : (
+      <DiscordPane />
+    );
 
   return (
     <Layout>
@@ -153,7 +173,7 @@ const Profile = () => {
             />
           </TabPane>
           <TabPane tab="Discord" key={5}>
-            <DiscordPane />
+            {discPane}
           </TabPane>
         </Tabs>
       </Content>

--- a/src/views/Profile/Profile.tsx
+++ b/src/views/Profile/Profile.tsx
@@ -7,6 +7,7 @@ import { profile } from "../../api/state";
 import { useRecoilValue } from "recoil";
 import { useHistory } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
+import DiscordPane from "./Discord";
 const { Content } = Layout;
 const { TabPane } = Tabs;
 
@@ -150,6 +151,9 @@ const Profile = () => {
               text="Update Profile Information"
               redirectURL="/newprofile"
             />
+          </TabPane>
+          <TabPane tab="Discord" key={5}>
+            <DiscordPane />
           </TabPane>
         </Tabs>
       </Content>


### PR DESCRIPTION
Code Changes
 - New Discord Tab available on the profile page
 - Setup UI for 3 stage linking process with Ant Design components
 - Expand profile interface to include fields that pertain to discord (`snowflake`, `username` & `discriminator`)
 - Display snowflake & username#discriminator if account linking is complete, else show connector service.

Auth0 Changes
 - Previous "Sign in with discord" social connector removed
 - New custom OAuth2.0 connector created
   - The old one only supported the `identify` and `email` scopes which were insufficient for the portal to connect with a specific guild (guild == server). 
   - New connector supports the `guild` scope as well
   - New connector also supports fine grained control over the authorization, token and revocation URLs
   - New connector supports custom script that will sync discord profile with Auth0 metadata (meaning auth0 will store fields like snowflake, username, discriminator, etc). 
   - Above change will cause profiles to sync on every login
   - New connector will look for email matches and allow accounts to merge and be linked. This will allow people to sync their profiles once & thereafter login with google-oauth and still be able to access their discord information
 - People who had previously used the "sign in with discord" option will need to re-authenticate since new scopes have been added