### PR TITLE
Feature/officer tools surfaced

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import "./App.css";
 import { Route, Switch, BrowserRouter } from "react-router-dom";
 import Welcome from "./views/Message/Welcome";
 import GsuiteLanding from "./views/Message/GsuiteLanding";
-import { pro, vanity, email, event } from "./config/typeform_config";
+import { pro, vanity, email, event, form } from "./config/typeform_config";
 import CalendarPage from "./views/Calendar/Calendar";
 import EventPage from "./views/Message/Event";
 import * as Sentry from "@sentry/react";
@@ -84,6 +84,10 @@ function App() {
           <GsuiteProtectedRoute
             path="/email"
             Component={<ProfileInjectedTypeform typeform_id={email} />}
+          />
+          <GsuiteProtectedRoute
+            path="/form"
+            Component={<ProfileInjectedTypeform typeform_id={form} />}
           />
           <Route path="/*" component={Message404} />
         </Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import "./App.css";
 import { Route, Switch, BrowserRouter } from "react-router-dom";
 import Welcome from "./views/Message/Welcome";
 import GsuiteLanding from "./views/Message/GsuiteLanding";
-import { pro } from "./config/typeform_config";
+import { pro, vanity, email, event } from "./config/typeform_config";
 import CalendarPage from "./views/Calendar/Calendar";
 import EventPage from "./views/Message/Event";
 import * as Sentry from "@sentry/react";
@@ -18,6 +18,7 @@ import { jwt } from "./api/state";
 import { useRecoilState } from "recoil";
 import CustomForm from "./views/Message/CustomForm";
 import Authorize from "./components/Actions/Authorize";
+import ProfileInjectedTypeform from "./views/ProfileInjectedTypeform";
 
 /**
  * Note: Use Component with Capital C when using a protected route
@@ -71,6 +72,18 @@ function App() {
           <GsuiteProtectedRoute
             path="/tothemoon"
             Component={<GsuiteLanding title="Yay gsuite auth works! 🚀" />}
+          />
+          <GsuiteProtectedRoute
+            path="/vanity"
+            Component={<ProfileInjectedTypeform typeform_id={vanity} />}
+          />
+          <GsuiteProtectedRoute
+            path="/event"
+            Component={<ProfileInjectedTypeform typeform_id={event} />}
+          />
+          <GsuiteProtectedRoute
+            path="/email"
+            Component={<ProfileInjectedTypeform typeform_id={email} />}
           />
           <Route path="/*" component={Message404} />
         </Switch>

--- a/src/config/typeform_config.ts
+++ b/src/config/typeform_config.ts
@@ -1,3 +1,5 @@
 export const vanity = process.env.REACT_APP_VANITY_TYPEFORM as string;
 export const pro = process.env.REACT_APP_PROFILE_TYPEFORM as string;
 export const survey = process.env.REACT_APP_PARTICIPATION_TYPEFORM as string;
+export const event = process.env.REACT_APP_EVENT_TYPEFORM as string;
+export const email = process.env.REACT_APP_SENDGRID_TYPEFORM as string;

--- a/src/config/typeform_config.ts
+++ b/src/config/typeform_config.ts
@@ -3,3 +3,5 @@ export const pro = process.env.REACT_APP_PROFILE_TYPEFORM as string;
 export const survey = process.env.REACT_APP_PARTICIPATION_TYPEFORM as string;
 export const event = process.env.REACT_APP_EVENT_TYPEFORM as string;
 export const email = process.env.REACT_APP_SENDGRID_TYPEFORM as string;
+export const form = process.env.REACT_APP_FORM_ADDER_TYPEFORM as string
+export const unauthorized_form = process.env.REACT_APP_UNAUTHORIZED_TYPEFORM as string;

--- a/src/views/ProfileInjectedTypeform.tsx
+++ b/src/views/ProfileInjectedTypeform.tsx
@@ -2,36 +2,48 @@ import React from "react";
 import Typeform from "../components/Typeform/typeform";
 import { useRecoilValue } from "recoil";
 import { auth_gsuite } from "../api/state";
+import { unauthorized_form } from "../config/typeform_config";
 
 interface message {
   typeform_id: string;
 }
-const ProfileInjectedTypeform = (props: message) => {
+
+const CapitalizeWord = (word: string) => {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+};
+
+const ProfileInjectedTypeform = ({ typeform_id }: message) => {
   const auth_status = useRecoilValue(auth_gsuite);
-  const email =
-    auth_status.decoded_jwt === undefined
-      ? undefined
-      : auth_status.decoded_jwt["email"];
-  const name = email!.split("@")[0];
-  const firstName =
-    name.split(".")[0].charAt(0).toUpperCase() + name.split(".")[0].slice(1);
-  const lastName =
-    name.split(".")[1].charAt(0).toUpperCase() + name.split(".")[1].slice(1);
-  const typeform_id = props.typeform_id;
+
+  if (auth_status.is_verified) {
+    const email = auth_status.decoded_jwt!["email"];
+    const name = email!.split("@")[0];
+    const firstName = CapitalizeWord(name.split(".")[0]);
+    const lastName = CapitalizeWord(name.split(".")[1]);
+
+    return (
+      <div>
+        <Typeform
+          tfLink={
+            "https://acmutd.typeform.com/to/" +
+            typeform_id +
+            "#email=" +
+            email +
+            "&first_name=" +
+            firstName +
+            "&last_name=" +
+            lastName
+          }
+          style={{ height: "100vh" }}
+        />
+      </div>
+    );
+  }
 
   return (
     <div>
       <Typeform
-        tfLink={
-          "https://acmutd.typeform.com/to/" +
-          typeform_id +
-          "#email=" +
-          email +
-          "&first_name=" +
-          firstName +
-          "&last_name=" +
-          lastName
-        }
+        tfLink={"https://acmutd.typeform.com/to/" + unauthorized_form}
         style={{ height: "100vh" }}
       />
     </div>

--- a/src/views/ProfileInjectedTypeform.tsx
+++ b/src/views/ProfileInjectedTypeform.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import Typeform from "../components/Typeform/typeform";
+import { useRecoilValue } from "recoil";
+import { auth_gsuite } from "../api/state";
+
+interface message {
+  typeform_id: string;
+}
+const ProfileInjectedTypeform = (props: message) => {
+  const auth_status = useRecoilValue(auth_gsuite);
+  const email =
+    auth_status.decoded_jwt === undefined
+      ? undefined
+      : auth_status.decoded_jwt["email"];
+  const name = email!.split("@")[0];
+  const firstName =
+    name.split(".")[0].charAt(0).toUpperCase() + name.split(".")[0].slice(1);
+  const lastName =
+    name.split(".")[1].charAt(0).toUpperCase() + name.split(".")[1].slice(1);
+  const typeform_id = props.typeform_id;
+
+  return (
+    <div>
+      <Typeform
+        tfLink={
+          "https://acmutd.typeform.com/to/" +
+          typeform_id +
+          "#email=" +
+          email +
+          "&first_name=" +
+          firstName +
+          "&last_name=" +
+          lastName
+        }
+        style={{ height: "100vh" }}
+      />
+    </div>
+  );
+};
+
+export default ProfileInjectedTypeform;


### PR DESCRIPTION
- Currently portal is hosted separate from vanity link generator, event checkin generator. This PR consolidates this and allows us to deploy one instance of portal
- Adds routes for the officer tools on the current dev branch. The officer tools were updated to use the latest logic for authentication and authorization using `<GsuiteProtectedRoute/>`
- Component to inject a user's name and email any Typeform given the Typeform id. 
- <root-url>/vanity
- <root-url>/event
- <root-url>/email
- <root-url>/form